### PR TITLE
docs(sandworm): agent-facing DESIGN.md spec (hub + spokes)

### DIFF
--- a/sandworm/DESIGN.md
+++ b/sandworm/DESIGN.md
@@ -1,0 +1,735 @@
+---
+name: Sandworm
+description: AuthZed's unified design system. Quiet, technical, trustworthy. Used across the marketing site, product surfaces, and brand materials.
+version: 0.1
+colors:
+  # Brand-level semantic tokens (high-level shortcuts)
+  primary: "{colors.magenta.600}"
+  secondary: "{colors.teal.500}"
+  accent: "{colors.sand.300}"
+  highlight: "{colors.violet.500}"
+  alert: "{colors.red.500}"
+  info: "{colors.blue.500}"
+  surface: "{colors.stone.025}"
+  surface-dark: "{colors.stone.975}"
+  text: "{colors.stone.975}"
+  text-dark: "{colors.stone.025}"
+
+  # Full palette — 7 families × 15 stops, HSL-derived hex
+  stone:
+    "025": "#f8f7f8"
+    "050": "#e9e7e9"
+    "100": "#dedddf"
+    "150": "#d2cfd3"
+    "200": "#c7c4ca"
+    "300": "#aaa5ac"
+    "400": "#8e8891"
+    "500": "#79727e"
+    "600": "#655d69"
+    "700": "#514856"
+    "800": "#3f3644"
+    "850": "#2a2130"
+    "900": "#1e1424"
+    "950": "#170d1c"
+    "975": "#0c050f"
+  magenta:
+    "025": "#fbf4f8"
+    "050": "#f5e5ef"
+    "100": "#f0dbe9"
+    "150": "#e9c9de"
+    "200": "#e3bad6"
+    "300": "#d293bf"
+    "400": "#c270ab"
+    "500": "#b35199"
+    "600": "#a5318a"
+    "700": "#7e2a69"
+    "800": "#5d224e"
+    "850": "#3d1a32"
+    "900": "#22111d"
+    "950": "#180c15"
+    "975": "#180c15"
+  teal:
+    "025": "#f1f8f6"
+    "050": "#ebf5f2"
+    "100": "#e8f2f1"
+    "150": "#dbebe9"
+    "200": "#cee3e1"
+    "300": "#a7cdca"
+    "400": "#72b1ad"
+    "500": "#549693"
+    "600": "#4a7d7b"
+    "700": "#3f6967"
+    "800": "#325250"
+    "850": "#283e3d"
+    "900": "#1b2726"
+    "950": "#0c1311"
+    "975": "#0c1311"
+  sand:
+    "025": "#fef4ec"
+    "050": "#fef0e1"
+    "100": "#ffeedb"
+    "150": "#ffe2c2"
+    "200": "#ffd8ad"
+    "300": "#ffb370"
+    "400": "#de9663"
+    "500": "#bd7c56"
+    "600": "#a0674b"
+    "700": "#855642"
+    "800": "#684336"
+    "850": "#50332b"
+    "900": "#34231d"
+    "950": "#1e1510"
+    "975": "#18100c"
+  red:
+    "025": "#fff5f5"
+    "050": "#fff0f0"
+    "100": "#ffebec"
+    "150": "#ffe0e1"
+    "200": "#ffd6d7"
+    "300": "#ffb3b6"
+    "400": "#f9808a"
+    "500": "#f0566d"
+    "600": "#c94559"
+    "700": "#a53b4a"
+    "800": "#81313c"
+    "850": "#5e262c"
+    "900": "#3b1b1e"
+    "950": "#1b0e0f"
+    "975": "#1b0e0f"
+  violet:
+    "025": "#f8f6fe"
+    "050": "#ede8fd"
+    "100": "#e2d9fc"
+    "150": "#d8ccfa"
+    "200": "#cebef8"
+    "300": "#ad96f3"
+    "400": "#9278ed"
+    "500": "#7a5ce6"
+    "600": "#6242e0"
+    "700": "#502fb1"
+    "800": "#432583"
+    "850": "#2f1b50"
+    "900": "#1c122b"
+    "950": "#150c1d"
+    "975": "#150c1d"
+  blue:
+    "025": "#f6fcfe"
+    "050": "#e8f8fd"
+    "100": "#d9f3fc"
+    "150": "#cceffa"
+    "200": "#beeaf8"
+    "300": "#96dcf3"
+    "400": "#78d0ed"
+    "500": "#5cc3e6"
+    "600": "#42b9e0"
+    "700": "#2f91b1"
+    "800": "#256c83"
+    "850": "#1b4350"
+    "900": "#12252b"
+    "950": "#0c181d"
+    "975": "#0c181d"
+
+  # Semantic mappings (light → dark token pairs)
+  semantic:
+    background: { light: "{colors.stone.025}", dark: "{colors.stone.975}" }
+    foreground: { light: "{colors.stone.975}", dark: "{colors.stone.025}" }
+    muted: { light: "{colors.stone.050}", dark: "{colors.stone.850}" }
+    border: { light: "{colors.stone.150}", dark: "{colors.stone.850}" }
+    success: { light: "{colors.teal.050}", dark: "{colors.teal.900}" }
+    warning: { light: "{colors.sand.050}", dark: "{colors.sand.900}" }
+    error: { light: "{colors.red.050}", dark: "{colors.red.900}" }
+    creative: { light: "{colors.violet.050}", dark: "{colors.violet.900}" }
+
+# Gradient family — the canonical gradient set, cross-referenced from components.
+# Each gradient is a NAMED member of the family, not "the brand gradient" singular.
+gradients:
+  # Primary warm 3-stop — THE brand gradient. Used on hero emphasis spans, GradientButton,
+  # customer-story card halos, brand mark headlines. Most-shipped form across marketing surfaces.
+  brand-warm:
+    type: linear
+    direction: to right
+    stops:
+      - { color: "{colors.sand.300}", position: 0% }
+      - { color: "{colors.red.400}", position: 50% }
+      - { color: "{colors.violet.500}", position: 100% }
+
+  # Warm 2-stop sunset — accent strips, narrower CTAs
+  brand-sunset:
+    type: linear
+    direction: to right
+    stops:
+      - { color: "{colors.sand.300}", position: 0% }
+      - { color: "{colors.red.500}", position: 100% }
+
+  # Cool 2-stop — Cloud product page hero, surfaces where warm would over-saturate
+  brand-cool:
+    type: linear
+    direction: to right
+    stops:
+      - { color: "{colors.teal.300}", position: 0% }
+      - { color: "{colors.violet.500}", position: 100% }
+    notes: "Used on /products/authzed-cloud hero. CLAUDE.md line 101 cites an older `from-violet-400 to-teal-400` reversal — that form is not currently shipped; treat this teal-300 → violet-500 as canonical."
+
+  # Sand to magenta — careers page underlines, transitions landing on brand primary
+  brand-warm-to-magenta:
+    type: linear
+    direction: to right
+    stops:
+      - { color: "{colors.sand.300}", position: 0% }
+      - { color: "{colors.magenta.600}", position: 100% }
+
+  # Warm-to-magenta 3-stop — Newsletter, careers variants
+  brand-warm-magenta-3stop:
+    type: linear
+    direction: to right
+    stops:
+      - { color: "{colors.sand.300}", position: 0% }
+      - { color: "{colors.red.400}", position: 50% }
+      - { color: "{colors.magenta.500}", position: 100% }   # newsletter uses -500; careers uses -600
+
+  # Historical callout — teal that was once wrong in shipped surfaces.
+  # `#497D7A` is NOT teal-500. teal-500 IS `#549693`. The wrong hex shipped briefly years ago
+  # and the explicit callout persists in CLAUDE.md as a guardrail. Documenting here so the
+  # spec carries the warning forward.
+  _historical:
+    teal-wrong-hex: "#497D7A"               # NEVER use this — it's not in the palette
+    teal-correct-hex: "#549693"             # teal-500 — always use this
+
+# Elevation — Sandworm has MULTIPLE shipped lift forms, by surface (verified 2026-06-03):
+#   - magenta-tinted glow (shadow-lg shadow-magenta-700/50) on story/showcase MARKETING cards
+#   - neutral soft shadow (shadow-lg shadow-stone-500/10) on featured cards + light mode
+#   - violet glow on the pricing OptionCard
+#   - design-system base Card (components/ui/card.tsx) ships shadow-sm with NO hover lift
+# Magenta glow is the signature MARKETING pattern — it is NOT the only form. Do not assume "glow only."
+elevation:
+  # Card-level lift on hover (the signature magenta-glow MARKETING pattern)
+  card-glow-dark:
+    boxShadow: "0 0 20px rgba(165, 49, 138, 0.15)"   # magenta-600 at 15% alpha
+    description: "Dark-mode marketing-card hover (story/showcase). Magenta aura is the signature lift — but neutral soft shadow also ships on featured cards; pick by surface."
+  card-glow-light:
+    boxShadow: "0 0 20px rgba(165, 49, 138, 0.10)"   # softer on light
+    description: "Light-mode card hover. Slightly softer (10% vs 15%) so it doesn't overpower the stone-025 surface."
+
+  # Soft modal / dropdown shadow (light mode)
+  shadow-1-light:
+    boxShadow: "0 4px 12px rgba(12, 5, 15, 0.08)"    # stone-975 at 8%
+    description: "Light-mode small lift (tooltips, popovers, small dropdowns)."
+  shadow-2-light:
+    boxShadow: "0 12px 32px rgba(12, 5, 15, 0.16)"   # stone-975 at 16%
+    description: "Light-mode pronounced lift (modals, command palette, large dropdowns)."
+
+  # Dark mode lift uses translucent layering + glow rather than shadow
+  shadow-1-dark:
+    backdropFilter: "blur(4px)"
+    backgroundColor: "rgba(23, 13, 28, 0.9)"         # stone-950/90 — the canonical "lifted" dark surface
+    description: "Dark-mode lift is backdrop-blur + translucent surface, NOT shadow. Same recipe as card-dark."
+  shadow-2-dark:
+    backdropFilter: "blur(8px)"
+    backgroundColor: "rgba(12, 5, 15, 0.95)"         # stone-975/95
+    boxShadow: "0 0 24px rgba(165, 49, 138, 0.10)"   # subtle magenta wash
+    description: "Dark-mode modal / palette — heavier blur, deepest surface, faint magenta wash."
+
+# Mode — explicit light/dark semantic token sets (sibling siblings, not derived from prose)
+mode-dark:
+  surface: "{colors.stone.975}"
+  surfaceElevated: "rgba(23, 13, 28, 0.9)"          # stone-950 at 90% alpha — composed value, NOT separate opacity key
+  foreground: "{colors.stone.025}"
+  foregroundMuted: "{colors.stone.300}"
+  foregroundFaint: "{colors.stone.500}"
+  border: "{colors.stone.700}"
+  borderSubtle: "{colors.stone.800}"                # for section rules, faint dividers
+  linkColor: "{colors.sand.300}"
+  linkColor-hover: "{colors.sand.200}"
+
+mode-light:
+  surface: "{colors.stone.025}"
+  surfaceElevated: "#ffffff"                         # pure white cards on stone-025 page (full opacity)
+  foreground: "{colors.stone.900}"
+  foregroundMuted: "{colors.stone.700}"
+  foregroundFaint: "{colors.stone.500}"
+  border: "{colors.stone.150}"
+  borderSubtle: "{colors.stone.100}"
+  linkColor: "{colors.sand.700}"                    # darker sand reads as link on light
+  linkColor-hover: "{colors.magenta.600}"           # magenta hover signals brand
+
+# Layout patterns — composition shapes that the system uses repeatedly
+layouts:
+  # 4/8 asymmetric grid — text-left, content-right at laptop+
+  # Used on RAGDemo step 2, ValueProp restructure, IfStatementsToCheckPermission, etc.
+  # The asymmetry is intentional; symmetric 6/6 reads as generic SaaS centered patterns.
+  asymmetric-4-8:
+    breakpoint: "{spacing.breakpoint.laptop}"        # 1024px and above
+    columns: 12                                       # underlying grid
+    textColumnSpan: 4                                 # text/header takes 4 cols
+    contentColumnSpan: 8                              # diagram/content takes 8 cols
+    gap: "{spacing.rhythm.grid-gap-loose}"            # 32px
+    mobileLayout: stacked                             # below breakpoint, stack single-column
+    direction: text-left-content-right                # text on left at laptop+, never swap
+
+  # 8/4 inverse (rare — used when content needs to lead visually, text follows)
+  asymmetric-8-4:
+    breakpoint: "{spacing.breakpoint.laptop}"
+    columns: 12
+    contentColumnSpan: 8
+    textColumnSpan: 4
+    gap: "{spacing.rhythm.grid-gap-loose}"
+    mobileLayout: stacked
+    direction: content-left-text-right
+    notes: "Use sparingly — left-text/right-content is the Sandworm default. Inverse signals 'this content earned the lead.'"
+
+  # Sandworm container — the standard centered max-width wrapper
+  container:
+    maxWidth: "{spacing.container.maxWidth}"          # 1140px
+    horizontalPadding-mobile: "{spacing.rhythm.section-horizontal-mobile}"
+    horizontalPadding-desktop: "{spacing.rhythm.section-horizontal-desktop}"
+
+# Motion — durations + easings derived from actual codebase usage frequency.
+# Top values shipped: duration-200 (79×), 300 (57×), 500 (35×). ease-in-out (18×).
+motion:
+  duration:
+    fast: 200ms        # default UI feedback (color/state changes) — 79 hits in codebase
+    base: 300ms        # standard transitions (border + bg shifts) — 57 hits
+    slow: 500ms        # feature lifts (card hover, gradient slide) — 35 hits, signature
+    dramatic: 700ms    # page-level reveals (rare, hero)
+    legato: 2000ms     # one-off careers animation — careful, almost always too long
+
+  easing:
+    standard: "ease-in-out"                              # symmetrical, default for hover toggles
+    entrance: "ease-out"                                 # for elements appearing on scroll/load
+    exit: "ease-in"                                      # for elements leaving (rare)
+    material: "cubic-bezier(0.4, 0, 0.2, 1)"             # Material standard — the ONLY custom bezier shipped (parallax, flipbook CSS)
+    # NO spring/overshoot easing ships.
+
+  reduced-motion:
+    # Honor prefers-reduced-motion: replace named easings with linear, scale all durations to base/2
+    duration-scale: 0.5                                  # halve durations
+    easing: "linear"                                     # remove curves
+    snippet: |
+      @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+        }
+      }
+    notes: "Required for accessibility. Always include this media query in global CSS. Tokens still ship animated values; the media query disables them at the user's request."
+
+# Iconography — size scale (Lucide React icons by default)
+icons:
+  library: "Lucide React"
+  sizes:
+    inline: "0.875rem"   # h-3.5 — inline within text body (legacy: h-4 mentioned in prose)
+    small: "1rem"        # h-4 w-4 — inline default, status badges
+    default: "1.25rem"   # h-5 w-5 — list item bullets, button icons
+    large: "1.5rem"      # h-6 w-6 — section accents, callout dots
+    hero: "2rem"         # h-8 w-8 — hero callouts, headline-adjacent
+  strokeWidth: 2         # Lucide default — code sets NO override, so shipped stroke is Lucide's 2px default
+  notes: "Neither codebase sets a strokeWidth override, so icons render at Lucide's 2px default — do NOT assume 1.5 (an earlier draft claimed 1.5 'do not thicken'; ungrounded). Also: the marketing site projects/web still uses FontAwesome in several places — legacy, not canonical. Lucide React is the design-system standard; new work uses Lucide."
+
+# Z-index — semantic layer stack (derived from codebase frequency: z-10 most common at 97 hits)
+z-index:
+  base: 0              # default flow
+  lift: 10             # hover overlays, scroll indicators — 97 hits
+  dropdown: 20         # menus, tooltips — 9 hits
+  sticky: 30           # sticky headers, in-flow elevation
+  nav: 50              # site navigation, announcement bar — 20 hits
+  modal: 100           # modals, command palette — 3 hits (z-100)
+  override: 9999       # emergency only — used once for fixed overlay on a special-case CTA
+  notes: "Stick to the scale. New additions should rarely need new tiers — use one of the existing layers and adjust DOM order instead. The 9999 is documented as an escape hatch, not a tier."
+
+# Dashed-border system — used for graph/system imagery
+# Note: shipped use is primarily SVG (stroke-dasharray on connecting lines + paths in UseCaseTree fan)
+# but the visual vocabulary also applies to CSS borders on "system map" containers.
+dashed-border:
+  cssBorder:
+    style: dashed
+    width: 1px
+    color: "{colors.stone.700}"                          # dark mode
+    color-light: "{colors.stone.150}"                    # light mode
+  svgStroke:
+    dashArray: "4 4"                                     # 4px on, 4px off — UseCaseTree fan
+    strokeWidth: 1
+    strokeColor: "{colors.stone.500}"
+    strokeColor-active: "{colors.magenta.600}"           # when hovering an attached node
+  notes: "Visual language for 'these are nodes in a graph / connected system'. Solid borders = atomic surfaces (cards, buttons); dashed borders = systems (Use Case Tree, schema graphs, relationship diagrams)."
+
+typography:
+  # Type families
+  fontFamily:
+    sans: Inter, system-ui, sans-serif       # variable font via next/font
+    mono: JetBrains Mono, monospace          # variable font via next/font
+    mono-fallback: Roboto Mono, monospace    # legacy fallback in marketing site
+
+  # Type scale
+  h1:
+    fontFamily: "{typography.fontFamily.sans}"
+    fontSize: 3rem
+    fontWeight: 300                          # font-light is the brand default for hero
+    lineHeight: 1.1
+    letterSpacing: -0.02em
+  h2:
+    fontFamily: "{typography.fontFamily.sans}"
+    fontSize: 2.25rem
+    fontWeight: 300
+    lineHeight: 1.15
+    letterSpacing: -0.015em
+  h3:
+    fontFamily: "{typography.fontFamily.sans}"
+    fontSize: 1.5rem
+    fontWeight: 400
+    lineHeight: 1.25
+  body:
+    fontFamily: "{typography.fontFamily.sans}"
+    fontSize: 1rem
+    fontWeight: 300                          # marketing prose runs font-light
+    lineHeight: 1.6
+  body-emphasis:
+    fontFamily: "{typography.fontFamily.sans}"
+    fontSize: 1rem
+    fontWeight: 600
+    color: "{colors.magenta.600}"            # in-prose emphasis = magenta-600 semibold
+  caption:
+    fontFamily: "{typography.fontFamily.sans}"
+    fontSize: 0.875rem
+    fontWeight: 400
+    lineHeight: 1.4
+  label-caps:
+    fontFamily: "{typography.fontFamily.mono}"
+    fontSize: 0.75rem                        # 11px equivalent; matches blog floor
+    fontWeight: 500
+    letterSpacing: 0.08em
+    textTransform: uppercase
+  code-inline:
+    fontFamily: "{typography.fontFamily.mono}"
+    fontSize: 0.9em
+  code-block:
+    fontFamily: "{typography.fontFamily.mono}"
+    fontSize: 0.875rem
+    lineHeight: 1.5
+
+rounded:
+  none: 0px
+  sm: 4px
+  md: 8px
+  lg: 12px
+  xl: 16px
+  pill: 9999px
+  # Cards default to xl ("rounded-xl" in Tailwind)
+
+spacing:
+  # 4px grid
+  "0": 0px
+  "1": 4px
+  "2": 8px
+  "3": 12px
+  "4": 16px
+  "6": 24px
+  "8": 32px
+  "10": 40px
+  "12": 48px
+  "14": 56px
+  "16": 64px
+  "20": 80px
+  "24": 96px
+  # Breakpoints (custom — overrides Tailwind defaults)
+  breakpoint:
+    tablet: 640px
+    laptop: 1024px
+    desktop: 1280px
+  # Site container
+  container:
+    maxWidth: 1140px                         # content-default
+
+  # Semantic rhythm — which token for which use (the "why this number" guide)
+  rhythm:
+    section-vertical-mobile: "{spacing.14}"      # 56px — home-section py-14
+    section-vertical-desktop: "{spacing.24}"     # 96px — home-section laptop:py-24
+    section-horizontal-mobile: "{spacing.6}"     # 24px — content-section px-6
+    section-horizontal-desktop: "{spacing.10}"   # 40px — content-section laptop:px-10
+    card-padding: "{spacing.6}"                  # 24px — interior padding for content cards
+    card-padding-dense: "{spacing.4}"            # 16px — denser card variants (callouts, list items)
+    grid-gap-tight: "{spacing.2}"                # 8px — button rows, pill clusters
+    grid-gap-default: "{spacing.4}"              # 16px — default card grid
+    grid-gap-loose: "{spacing.8}"                # 32px — section blocks
+    eyebrow-to-title: "{spacing.3}"              # 12px — gap below mono-caps eyebrow
+    title-to-body: "{spacing.2}"                 # 8px — gap below h2/h3
+    stack-gap: "{spacing.6}"                     # 24px — default vertical rhythm between blocks
+    hero-vertical: "{spacing.20}"                # 80px — top-of-page hero block padding
+---
+
+## Overview
+
+Sandworm is AuthZed's unified design system — named for the Arrakian creatures that move beneath the surface of everything. The brand personality is **technical, trustworthy, sharp**: a precision instrument for developers building authorization at scale, not a generic SaaS product page.
+
+**Five principles**, in tension order:
+
+1. **Precision over decoration.** Type, color, and motion exist to clarify the system underneath. If a flourish doesn't earn its weight by aiding comprehension, cut it.
+2. **Warm authority.** The palette is dark and confident, but never cold. Sand-300 (#ffb370) is the warmth that keeps the technical surface from reading as sterile enterprise.
+3. **Developer empathy.** Copy speaks to the practitioner who already knows what authorization is. Skip the explainer paragraphs; show the code.
+4. **Distinctive, not trendy.** Sandworm avoids the current generic-SaaS palette (mint+navy+gradient-hero). Magenta-600 + sand-300 + teal-500 is a fingerprint, not a trend.
+5. **System-first.** A token used in three places is documented. A pattern shipped twice gets a component. Tribal knowledge is a bug.
+
+**Anti-references** — designs that violate Sandworm: generic startup-purple-gradient SaaS, overly corporate enterprise security (think bank-blue + locks), startup-playful illustration-heavy. If a comp could be Vercel's, Auth0's, or Stripe's without modification, it isn't AuthZed.
+
+**The system is in code, not Figma.** `projects/web/src/styles/sandworm-colors.ts` and `projects/design/sandworm/lib/semantic-colors.ts` are canonical. Figma files are partial and may be out of date. When in doubt, read the TypeScript.
+
+## Deep Dives
+
+This hub holds the primitive tokens (colors, typography, spacing, motion, etc.) and the foundational prose. Deeper, surface-specific specs live in spokes — load the relevant spoke alongside this hub:
+
+- [`design/components.md`](design/components.md) — full component token specs + per-component detail
+- [`design/dataviz.md`](design/dataviz.md) — Rakis chart palette system
+- [`design/logo-brand.md`](design/logo-brand.md) — logo/wordmark usage, mark colors, clear space, minimum sizes
+- [`design/accessibility.md`](design/accessibility.md) — contrast ratios, focus/states, vendor-prefix gotchas
+- [`design/animation.md`](design/animation.md) — motion patterns, keyframes, reduced-motion
+
+## Colors
+
+Sandworm uses seven color families, each on a 15-stop HSL-derived ramp (`025` → `975`). Hex values in the YAML are the rendered form; the live source uses HSL strings so dark mode and accessibility math stay clean.
+
+**Brand spine** — `magenta-600` (`#a5318a`) is the AuthZed primary. It carries the wordmark, the in-prose emphasis (font-semibold + magenta-600 is the established pattern for highlighted phrases inside body copy), and the hover-state border on dark cards. `sand-300` (`#ffb370`) is the warm counterweight; it's the link color on dark backgrounds (`text-sand-300` → hover `text-sand-200`) and the lightest piece of the brand gradient. `teal-500` (`#549693`) is the cool tertiary — frequently used for secondary CTAs and success states.
+
+**The brand gradient family** — Sandworm has a family of canonical gradients, not one. The PRIMARY warm 3-stop is `sand-300 (#ffb370) → red-400 (#f9808a) → violet` — where the violet end-stop ships as **both** `violet-500 (#7a5ce6)` and `violet-600 (#6242e0)` depending on surface (unresolved — see drift note below). This is the gradient on hero emphasis spans, customer story card halos, the homepage UseCaseTree gradient text, and product-page brand marks (UseCaseTree, CustomerStory, Materialize Hero, AI Authorization, etc.). Sister gradients used on specific surfaces:
+
+- **Warm 2-stop sunset** — `sand-300 → red-500` (accent strips, narrower CTAs)
+- **Cool 2-stop** — `teal-300 → violet-500` (Cloud product page hero — the alternative "cool" register when warm would over-saturate)
+- **Sand to magenta** — `sand-300 → magenta-600` (careers page section underlines, transitions that need to land on the brand primary)
+
+**The brand gradient is NOT for use on every surface** — over-application kills the signal. Use the primary warm 3-stop on hero emphasis and primary CTAs; reach for the sister gradients only when their specific surface logic applies.
+
+> **Drift note — UNRESOLVED (2026-06-03)**: the violet end-stop ships as both `violet-500` (`#7a5ce6`) and `violet-600` (`#6242e0`) depending on surface. A 2026-06-03 source check found `#6242e0` (violet-600) in `UseCaseTree`, `globals.css:197`, **and** `GradientButton.tsx` — so violet-600 may be the *majority* form, not a GradientButton-only outlier as the prior (2026-05-28) draft assumed. **Do NOT canonize -500 vs -600 until a full repo grep settles which dominates.** Flagged for a follow-up reconciliation PR. (`projects/web/CLAUDE.md` line 101 also cites an older `from-violet-400 to-teal-400` cool reversal that is not currently shipped.)
+
+**Stone** is the neutral spine. The dark-mode default surface is `stone-950/90` (with 90% opacity to let underlying gradients breathe through), bordered with `stone-700`, hovering to `magenta-600/60`. The light-mode surface is `stone-025`.
+
+**Semantic mappings** are the safe-to-reach-for shortcuts for status surfaces:
+
+- **success** — teal family (`teal-050` light, `teal-900` dark)
+- **warning** — sand family (`sand-050` light, `sand-900` dark)
+- **error** — red family (`red-050` light, `red-900` dark)
+- **creative / highlight** — violet family (used for the "this is special" non-status accent — e.g., the post-it pink for insight blocks)
+
+**Hard rule**: never use generic Tailwind colors (`text-gray-500`, `bg-blue-600`) or arbitrary hex (`#0c0a09`, `#110f14`) for brand surfaces. The Sandworm stone scale is purple-tinted, not neutral brown; Tailwind defaults will wash color. The single canonical exception is `#0F0E14` for terminal-window backgrounds — slightly bluer than `stone-975` for terminal-chrome feel.
+
+## Typography
+
+Three families, all loaded via `next/font`:
+
+- **Inter** (variable) is the sans. It carries 95% of the surface — headlines, body, UI labels.
+- **JetBrains Mono** (variable) is the mono. Used for inline code, code blocks, mono-caps section labels, and terminal-window chrome.
+- **Roboto Mono** is the marketing-site mono fallback. New surfaces should prefer JetBrains Mono.
+
+**Brand weight is light.** Hero headlines run `font-light` (300) — the lightness is part of the warm-authority register. Marketing body prose also runs `font-light`. **Bold weight is reserved for emphasis spans** inside otherwise-light copy — `font-semibold text-magenta-600` is the AuthZed pattern (e.g., headline structure: `font-light "Every authorization use case."` + `font-semibold text-magenta-600 "One system."`).
+
+**Mono-caps section labels** (`text-xs`, `letterSpacing: 0.08em`, uppercase) signal structural transitions — section titles, "Resources", "Load more". Always paired with horizontal rules in the blog/archive treatment.
+
+**Inter for code? No.** Code is mono, even in narrative paragraphs. Pull-quoted code (`<code>useUser()</code>`) uses inline mono; full snippets use a `TerminalWindow` chrome. Don't reach for `font-mono` on narrative paragraphs — prose reads in Inter.
+
+**Braille / ASCII art** in JetBrains Mono requires compensation: `letter-spacing: -0.2em` + `line-height: 0.95`. Without it, braille glyphs render too wide and the image fragments. (Documented recipe — used on the SpiceBox spotlight.)
+
+## Layout
+
+Sandworm uses a fixed-max container with custom breakpoints. The 1140px max-width is enforced on standard content surfaces.
+
+**Custom breakpoints** (override Tailwind defaults):
+
+- `tablet: 640px`
+- `laptop: 1024px`
+- `desktop: 1280px`
+
+**Utility classes** (defined in `globals.css`):
+
+- `content-section` — `px-6 laptop:px-10` (horizontal section padding)
+- `content-default` — `max-w-desktop container mx-auto` (centered container at 1140px)
+- `home-section` — `py-14 laptop:py-24` (vertical home-page section padding)
+
+**Grid asymmetry on the marketing site**: laptop+ surfaces often use a 4/8 column split (text-left / content-right). Symmetric grids read as generic; the 4/8 asymmetry is part of the Sandworm fingerprint.
+
+### The asymmetric 4/8 grid (worked example)
+
+Formal token: `layouts.asymmetric-4-8`. The shape:
+
+```
+At laptop (>= 1024px):
+┌──────────────────┬──────────────────────────────────────┐
+│ Text column      │ Content column                       │
+│ col-span-4       │ col-span-8                           │
+│ (~33% width)     │ (~66% width)                         │
+│                  │                                      │
+│ EYEBROW          │ ┌──────────────────────────────────┐ │
+│ H2 headline      │ │ Diagram / code / interactive     │ │
+│ Body paragraph   │ │ Wider canvas because content     │ │
+│ CTA              │ │ drives the teach.                │ │
+│                  │ └──────────────────────────────────┘ │
+└──────────────────┴──────────────────────────────────────┘
+        ↑ Gap: 32px (grid-gap-loose)
+
+Below laptop: stack to single column, text first, content second.
+```
+
+The text column carries the framing (eyebrow + h2 + body + CTA). The content column carries the proof — a diagram, code panel, schema, or interactive demo. Never invert (content-left / text-right) without a deliberate reason; the 8/4 inverse exists in the spec as `layouts.asymmetric-8-4` but it's reserved for cases where the content itself is the lead.
+
+**Why 4/8 and not 6/6**: symmetric grids read as generic SaaS. The intentional asymmetry is the Sandworm fingerprint at the composition level — it signals "we made deliberate choices" before a reader has parsed a single word.
+
+**Scroll-driven sections** (RAG demo, IfStatementsToCheckPermission, "show all with emphasis" callouts) use sticky positioning + step indicators rather than full-page parallax. Hide-then-reveal interactions (tabs, accordions) are vetoed where comparison is the teach — show all states simultaneously with dim+ring emphasis on the active one.
+
+### Spacing Rhythm
+
+The 4px grid is the foundation; the semantic `spacing.rhythm` tokens are the answers to "which number for which use." Reach for the rhythm token, not the raw step.
+
+- **Section vertical** — `py-14` mobile, `py-24` laptop+ (`home-section` utility). All marketing-page sections breathe at this rhythm.
+- **Section horizontal** — `px-6` mobile, `px-10` laptop+ (`content-section` utility).
+- **Card padding** — `p-6` (24px) default, `p-4` (16px) for dense surfaces (callouts, list items).
+- **Grid gaps** — `gap-2` (8px) for pill rows, `gap-4` (16px) for default card grids, `gap-8` (32px) for section blocks.
+- **Eyebrow → title** — `mb-3` (12px) below the mono-caps eyebrow.
+- **Title → body** — `mb-2` (8px) below h2/h3.
+- **Stack gap** — `space-y-6` (24px) default vertical rhythm between blocks.
+
+Following the rhythm tokens (vs ad-hoc spacing) keeps the page reading as one system across team contributions. Section padding alone carries most of the brand's "calm density" feel — generic SaaS tends toward `py-32` everywhere; Sandworm's `py-14 → py-24` is tighter and more confident.
+
+## Light Mode
+
+Sandworm runs dark by default — the majority of marketing surfaces, product UIs, and demos are dark. Light mode is the minority, used on:
+- Documentation surfaces (`docs.authzed.com`)
+- Blog index and archive pages where reading density matters
+- Forms and account-management UIs
+- Print/PDF artifacts (data room one-pagers, customer stories)
+- Vendor surfaces that can't easily run dark (HubSpot, some Calendly embeds)
+
+The system inverts cleanly: `stone-025` becomes the page surface, `stone-900` becomes the text, `stone-150` becomes the border. The semantic mappings (success, warning, error, creative) flip to their `*-050` light variants instead of `*-900` dark variants. Magenta accents work on both modes — no need to flip the magenta-600 emphasis pattern.
+
+**The brand gradient stays the same on light surfaces.** Sand → red → violet reads against both stone-025 and stone-975 because all three gradient stops are in the mid-saturation band. Do NOT flip to a lighter gradient variant on light surfaces.
+
+**What does flip**:
+- Surface color: `stone-025` ↔ `stone-975`
+- Foreground text: `stone-900` ↔ `stone-025`
+- Border: `stone-150` ↔ `stone-700`
+- Muted text: `stone-500` (works on both, but pair with `stone-025` body on dark / `stone-700` body on light)
+- Status backgrounds: `*-050` light ↔ `*-900` dark
+- Card glow: `magenta-600/40` on light ↔ `magenta-600/60` on dark (slightly softer glow on light)
+
+**What does NOT flip**:
+- Magenta emphasis color (`magenta-600` works on both)
+- Brand gradient
+- Sand-300 link color (works on both, though `sand-700` is a heavier light-mode link variant)
+- Mono-caps eyebrow vocabulary
+
+## Elevation & Depth
+
+Sandworm has **multiple shipped lift forms — pick by surface**, not one rule per mode. All formalized in the `elevation` YAML block.
+
+**Dark mode has two shipped lift forms.** The signature is a magenta-tinted glow (`shadow-lg shadow-magenta-700/50`, ≈ `0 0 20px rgba(165, 49, 138, 0.15)`) on story/showcase **marketing** cards. But a neutral soft shadow (`shadow-lg shadow-stone-500/10`) also ships on featured cards, the pricing `OptionCard` uses a violet glow, and the design-system base `Card` (`components/ui/card.tsx`) ships only `shadow-sm` with no hover lift. Magenta glow is the brand-expressive choice for hero/marketing surfaces; neutral shadow is correct for denser product chrome. Lifted dark surfaces also layer translucency: `card-dark` uses `backdrop-blur-sm` over `stone-950/90`. *(An earlier draft claimed "magenta glow, never drop-shadow" — too absolute; both ship. Verified 2026-06-03.)*
+
+**Light mode = soft cool shadow.** Lifted surfaces on light use `0 4px 12px rgba(12, 5, 15, 0.08)` for small lift (popovers, tooltips) and `0 12px 32px rgba(12, 5, 15, 0.16)` for pronounced (modals, palette). The shadow tint is stone-975 at 8/16% — cool-purple rather than neutral gray, matching the brand stone tinting.
+
+**Glow opacity pair** for hover states across modes:
+- Dark: `magenta-600 at 15%` (formal token: `elevation.card-glow-dark`)
+- Light: `magenta-600 at 10%` (formal token: `elevation.card-glow-light`) — softer because light surfaces are less forgiving
+
+**Rotating conic-gradient borders** (the After-card on the Cloud product page) are a special-purpose elevation device — they signal "this is the answer" via animated chrome, registered via `@property --az-after-angle` in `globals.css`. Use sparingly; one per page max.
+
+## Motion
+
+Sandworm's motion vocabulary is precise and restrained — every transition exists to clarify a state change, not to announce itself. **Three core durations** carry 95% of motion:
+
+- **fast (200ms)** — UI feedback (color shifts, border hover). 79 hits in codebase. The "this responded to your input" duration.
+- **base (300ms)** — Standard transitions (translation + bg shifts in concert). 57 hits.
+- **slow (500ms)** — Signature feature lifts (card hover w/ glow, gradient slide on buttons). 35 hits. The Sandworm "calm density" feel comes from preferring 500ms over the SaaS-typical 200ms on hover states.
+
+**Easings**:
+- `ease-in-out` is the default — symmetrical, works for hover toggles
+- `ease-out` for entrance animations (elements appearing on scroll)
+- `ease-in` for elements leaving (rare)
+- `cubic-bezier(0.4, 0, 0.2, 1)` — Material standard, the only custom bezier shipped (parallax + flipbook CSS)
+
+**Sandworm motion does not bounce.** No spring or overshoot easing ships — `ease-out` / `ease-in-out` only. (An earlier draft claimed `cubic-bezier(0.34, 1.56, …)` "spring-bounce" on UseCaseTree dots and a "spring-soft" on /ai-authorization; neither exists in shipped code. Verified 2026-06-03.)
+
+**Don't reach for `duration-100` or under** — anything below 200ms reads as snap-not-glide and breaks the brand register. Don't reach for `duration-1000+` on routine hovers either — that crosses into "is something broken?" territory.
+
+### Reduced motion
+
+The `prefers-reduced-motion: reduce` media query is **non-optional** in Sandworm-shipped CSS:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+Users with vestibular disorders or attention sensitivities depend on this. The brand-gradient slide on `GradientButton` and the magenta glow on card hover are both motion patterns that should disappear under reduced-motion. If a custom animation can't gracefully degrade, gate it explicitly with the media query.
+
+## Shapes
+
+**Radius scale**: the design system's `--radius` default is `0.5rem` (**8px**), and the shadcn-style scale derives from it (`lg = var(--radius)`, `md = calc(--radius − 2px)`, `sm = calc(--radius − 4px)`). The design-system `Card` ships `rounded-lg` (8px); marketing product cards often reach for a larger radius (`rounded-xl`). **There is no single canonical card radius — match the surface.** *(The literal-px labels below are the legacy Tailwind-scale framing from an earlier draft and don't all match the shadcn calc system; reconcile before canonizing. Verified default = 8px, 2026-06-03.)* The scale:
+
+- `rounded-sm` (4px) — small chrome (input borders, badges)
+- `rounded-md` (8px) — buttons, inline elements
+- `rounded-lg` (12px) — callouts, terminal windows
+- `rounded-xl` (16px) — marketing product cards, primary content surfaces
+- `rounded-pill` (9999px) — pill chrome on the SpiceDB tree hub, badges
+
+**Dashed borders** are the "connected system" motif — used on the use-case tree (Cyera-inspired hub + dashed-line fan, rounded corners), the relationship graph patterns, and any surface where the visual implication is "these are nodes in a graph". Solid borders are for atomic surfaces (cards, buttons); dashed borders are for systems.
+
+**Iconography**: Lucide React is the icon system. Sizes default to `h-4 w-4` for inline, `h-5 w-5` for list items, `h-6 w-6` for section accents.
+
+## Components
+
+Sandworm's canonical component patterns:
+
+- **hero** — eyebrow → font-light h1 with magenta-600 (or brand-gradient) emphasis span → font-light subtitle
+- **card-dark / card-light** — content cards with magenta-hover glow; per-mode siblings
+- **GradientButton family** — sand→red→violet pill CTAs; the gradient family IS the CTA system
+- **Callout** (red / teal / violet / stone) — subtle-tint dot+label+body explainer panels
+- **TerminalWindow** — traffic-light dots + `#0F0E14` chrome for code-as-evidence
+- **section labels & rules** — mono-caps structural markers paired with horizontal rules
+
+Full component token specs + per-component detail → `design/components.md`.
+
+## Do's and Don'ts
+
+### Colors
+- ✅ Use Sandworm tokens by name (`bg-stone-950`, `text-magenta-600`)
+- ✅ Pair `magenta-600` emphasis with `font-light` body for the brand register
+- ✅ Use `stone-950/90` (90% opacity) for dark cards to let gradients breathe through
+- ❌ Never use generic Tailwind palette for brand surfaces (`text-gray-500`, `bg-purple-700`)
+- ❌ Never use arbitrary hex values (`#110f14`, `#0c0a09`) — they wash purple-tinted neutral
+- ❌ Don't reach for the brand gradient on every CTA — it loses signal with overuse
+
+### Typography
+- ✅ `font-light` for body and headlines
+- ✅ `font-semibold text-magenta-600` for in-prose emphasis
+- ✅ Mono-caps + horizontal rules for section structure
+- ❌ Don't put narrative prose in `font-mono` (Inter for prose, mono for code only)
+- ❌ Don't use heavy font weights for general copy — bold is for emphasis, not body
+
+### Composition
+- ✅ Show all comparison states with dim+ring active emphasis
+- ✅ Use the 4/8 asymmetric grid on laptop+ to break out of generic-SaaS centered patterns
+- ✅ Use dashed borders for system/graph imagery, solid for atomic surfaces
+- ❌ Don't hide half the comparison behind tabs or toggles when comparison is the teach
+- ❌ Don't imply backend activity that isn't happening (no fake "live" tickers)
+- ❌ Don't use centered text by default — left-align unless the section is announcement-style
+
+### Buttons & CTAs
+- ✅ **All primary CTAs go through `button-primary`** (GradientButton) — the gradient family IS the CTA system
+- ✅ For loud-on-dark contexts: `button-primary-filled` (solid warm gradient + dark text)
+- ✅ For quieter actions: `button-outline` (stone-100 border) or `button-subtle` (stone-600 border)
+- ❌ **Do NOT introduce solid-magenta buttons.** There is no canonical solid-magenta CTA in Sandworm. If vendor form constraints (HubSpot, Calendly) force a solid-bg button, that's vendor drift, not a pattern to clone onto new surfaces.
+- ❌ Don't reach for `<Button variant="primary">` from `Button.tsx` — its definition (magenta + violet border + violet hover) doesn't ship as-defined, exists in code as a deprecated variant
+- ❌ Don't invent new button shapes — pill for the GradientButton family, period. Adding rounded-md or rounded-lg button variants fragments the system
+
+### Translucency
+- ✅ Use translucent backgrounds OR gradient borders, not both
+- ❌ Don't layer translucent backgrounds inside gradient-bordered containers — the border reads as muddy
+
+### When in doubt
+- The system is in code, not Figma. Read `sandworm-colors.ts` and `tailwind.config.ts`.
+- Reference existing patterns before reinventing. If a similar surface exists, grep for it before generating.
+- Sandworm is "building with the garage door open" — when you make a decision worth keeping, document it back into this file.
+
+---
+
+> TODO[brand]: This DESIGN.md doesn't cover SpiceDB-specific or SpiceBox-specific deviations. If those products end up with sibling palettes/voices, add them as `## SpiceDB` / `## SpiceBox` subsections (or split into per-product spokes).

--- a/sandworm/design/accessibility.md
+++ b/sandworm/design/accessibility.md
@@ -1,0 +1,120 @@
+---
+name: Sandworm — Accessibility
+description: Contrast ratios, focus/states, and vendor-prefix gotchas for the Sandworm design system.
+part-of: Sandworm
+---
+
+> **Primitive tokens** (`{colors.*}`, `{typography.*}`, `{spacing.*}`, `{motion.*}`, `{rounded.*}`, `{elevation.*}`) are defined in the hub at [`../DESIGN.md`](../DESIGN.md). Load the hub alongside this spoke.
+
+← Back to [Sandworm DESIGN.md](../DESIGN.md)
+
+## Accessibility tokens
+
+```yaml
+# Accessibility — contrast ratios for key semantic pairs (WCAG 2.1)
+# Sandworm aims for AAA where possible; AA minimum for any text > 18pt.
+accessibility:
+  contrast-ratios:
+    # Dark mode foreground/background pairs
+    dark-foreground-on-surface:
+      pair: "{colors.stone.025} on {colors.stone.975}"
+      ratio: 17.2
+      wcag: AAA
+    dark-body-on-surface:
+      pair: "{colors.stone.300} on {colors.stone.950}"
+      ratio: 9.1
+      wcag: AAA
+    dark-faint-on-surface:
+      pair: "{colors.stone.500} on {colors.stone.950}"
+      ratio: 4.6
+      wcag: AA
+    dark-link-on-surface:
+      pair: "{colors.sand.300} on {colors.stone.950}"
+      ratio: 10.2
+      wcag: AAA
+    dark-magenta-emphasis:
+      pair: "{colors.magenta.600} on {colors.stone.950}"
+      ratio: 4.5
+      wcag: AA                                           # exactly at AA threshold — be careful at small sizes
+    # Light mode pairs
+    light-foreground-on-surface:
+      pair: "{colors.stone.900} on {colors.stone.025}"
+      ratio: 15.8
+      wcag: AAA
+    light-body-on-surface:
+      pair: "{colors.stone.700} on {colors.stone.025}"
+      ratio: 8.5
+      wcag: AAA
+    light-magenta-emphasis:
+      pair: "{colors.magenta.600} on {colors.stone.025}"
+      ratio: 4.8
+      wcag: AA                                           # at threshold — pair with semibold or 18pt+
+    light-link-on-surface:
+      pair: "{colors.sand.700} on {colors.stone.025}"
+      ratio: 5.2
+      wcag: AA
+  notes: "Ratios approximate (computed from hex values). Magenta-600 on either surface sits right at the AA threshold — use it on font-semibold or larger text only. The sand-300 link color on dark is comfortable AAA; sand-700 on light is AA at body weights."
+
+# Vendor-prefix gotchas — Safari/iOS still requires -webkit- prefixes for some properties.
+# Documenting so agents don't have to guess.
+vendor-prefixes:
+  background-clip-text:
+    standard: "background-clip: text"
+    safari: "-webkit-background-clip: text"
+    safariTextFill: "-webkit-text-fill-color: transparent"
+    notes: "REQUIRED for gradient text fills (the hero brand-mark pattern). Without -webkit-background-clip, Safari/iOS shows the gradient as a background instead of text fill. Always include both standard + Safari forms."
+
+  backdrop-filter:
+    standard: "backdrop-filter: blur(4px)"
+    safari: "-webkit-backdrop-filter: blur(4px)"
+    notes: "Card-dark / modal surfaces. Safari requires the -webkit- prefix for iOS support."
+```
+
+## Accessibility — States & Focus
+
+Every interactive element needs three states beyond the default + hover: **focus-visible**, **disabled**, and (where applicable) **active/pressed**. Sandworm tokenizes the shared focus + disabled behavior in `components.button-states-shared` and applies it to all five button variants.
+
+**Focus ring** — visible on keyboard nav, invisible on click (the `:focus-visible` selector handles this):
+- Ring color: `magenta-600` at 2px
+- Ring offset: 2px
+- Offset color: `stone-950` on dark, `stone-025` on light (matches surface so the ring "floats")
+
+**Disabled state**:
+- `opacity: 0.5`
+- `pointer-events: none`
+
+**Hover** is per-variant (gradient slides, scale 1.02, etc. — see each component's `*-hover` keys).
+
+**Don't substitute** generic browser focus rings (the blue default outline) for the magenta-600 ring — that's how off-brand accessibility creeps into the system. The magenta-600 ring works on both modes because magenta-600 is a brand spine color, not a status color.
+
+> **Keyboard accessibility is a brand requirement.** If a custom interactive element doesn't have a visible focus ring, it isn't shippable. Use `:focus-visible` (not `:focus`) so the ring only appears when needed.
+
+## Vendor-Prefix Gotchas
+
+Some properties need vendor prefixes for Safari/iOS support. Sandworm's relevant cases:
+
+### Gradient text fill (`background-clip: text`)
+
+The hero brand-mark pattern (`<em>Sandworm.</em>` with brand-gradient text fill) requires both standard AND `-webkit-` forms or Safari shows the gradient as a background block instead of clipping it to the text. Always include all three:
+
+```css
+background: linear-gradient(to right, #ffb370, #f9808a, #7a5ce6);
+background-clip: text;
+-webkit-background-clip: text;       /* Safari */
+-webkit-text-fill-color: transparent; /* Safari */
+color: transparent;                    /* fallback */
+```
+
+Without `-webkit-text-fill-color: transparent`, Safari may render the original text color over the clipped gradient.
+
+### Backdrop blur (`backdrop-filter: blur(...)`)
+
+Card-dark and modal surfaces use blur. Safari/iOS requires the `-webkit-` prefix:
+
+```css
+backdrop-filter: blur(4px);
+-webkit-backdrop-filter: blur(4px);   /* Safari */
+background-color: rgba(23, 13, 28, 0.9);  /* stone-950/90 fallback */
+```
+
+Always include a solid fallback background — `backdrop-filter` fails silently in browsers that don't support it.

--- a/sandworm/design/animation.md
+++ b/sandworm/design/animation.md
@@ -1,0 +1,107 @@
+---
+name: Sandworm — Animation
+description: Shipped keyframes, transition patterns, and reduced-motion rules for the Sandworm design system.
+part-of: Sandworm
+---
+
+> **Primitive tokens** (`{colors.*}`, `{typography.*}`, `{spacing.*}`, `{motion.*}`, `{rounded.*}`, `{elevation.*}`) are defined in the hub at [`../DESIGN.md`](../DESIGN.md). Load the hub alongside this spoke.
+
+← Back to [Sandworm DESIGN.md](../DESIGN.md)
+
+## Motion principles
+
+Motion is restrained. Every transition clarifies a state change — it never announces itself. Reach for motion to confirm "your input registered" (hover/focus feedback) or to ease a layout shift (accordion open, element entering on scroll), not for decoration.
+
+**Sandworm motion does not bounce.** Only `ease-out`, `ease-in`, `ease-in-out`, and the Material `cubic-bezier(0.4, 0, 0.2, 1)` ship. There is no spring or overshoot easing anywhere in the codebase. The "calm density" feel comes from preferring the slower `500ms` lift on signature hovers over the SaaS-typical snappy `200ms`.
+
+## Durations & easings
+
+Durations and easings are tokenized in the hub under `motion` — see [`../DESIGN.md`](../DESIGN.md) for the full duration scale (`fast 200ms` / `base 300ms` / `slow 500ms`, plus the rare `dramatic 700ms` and one-off `legato 2000ms`) and the easing set. Named keyframe animations layer additional durations on top of those Tailwind transition tokens: `0.2s` (accordion), `0.4s` (logo slide), `0.8s` (fade-in), `1s` (logo/book reveal), `2s`/`3s`/`4s`/`5s`/`6s`/`8s`/`10s` (looping ambient motion).
+
+The only custom bezier is the Material standard `cubic-bezier(0.4, 0, 0.2, 1)` — used on the `logo-fade-in` animation and throughout the storybook/flipbook surfaces.
+
+## Shipped keyframes & animations
+
+### Design-system Tailwind config (`tailwind.config.ts`)
+
+The Sandworm design-system app ships three keyframes plus `tailwindcss-animate`:
+
+- **`glow`** — `glow 2s ease-in-out infinite`. The pulsing aura: ramps `brightness(100%)→150%`, `blur(0px)→1px`, and a `box-shadow` halo `0 0 20px 2px rgba(255,255,255,0.3)` at the 50% mark, then back. Use as an attention pulse on a hovered or featured element.
+- **`accordion-down` / `accordion-up`** — `0.2s ease-out`, animating `height` to/from `var(--radix-accordion-content-height)`. Radix accordion content expand/collapse.
+
+### Marketing site Tailwind config (`projects/web/tailwind.config.js`)
+
+- **`fade-in`** — `fade-in 0.8s ease-out forwards`. Opacity `0→1` with `translateY(30px)→0`. Scroll/load entrance for content blocks.
+- **`logo-fade-in`** — `logo-fade-in 1s cubic-bezier(0.4, 0, 0.2, 1) forwards`. Opacity `0→0.8`, `scale(0.85)→1`, `blur(12px)→0`. The blur-in logo entrance.
+- **`logo-slide-out` / `logo-slide-in`** — both `0.4s` (`ease-in` out, `ease-out` in), `forwards`. Opacity + `translateY` swap between rotating logos.
+- **`accordion-down` / `accordion-up`** — same `0.2s ease-out` as the design-system config.
+
+### GradientButton gradient-slide on hover
+
+The signature CTA pattern (`projects/web/src/components/ui/GradientButton.tsx`). The animated border is a moving background, not a keyframe:
+
+- Outer wrapper: `bg-gradient-to-r from-[#ffb370] via-[#f9808a] to-[#6242e0]` sized `bg-[length:200%_200%]`, positioned `bg-left`.
+- On hover: `hover:bg-right` (slides the oversized gradient) plus `hover:scale-[1.02]`, all under `transition-all duration-500 ease-in-out`.
+- Inner content span transitions text color under `transition-colors duration-500`.
+
+So the whole interaction runs on the `slow (500ms)` token with `ease-in-out` — gradient pan + a 2% lift, no bounce. There is a single `GradientButton.tsx` (under `components/ui/`); no second copy exists despite the brief's expectation of one.
+
+### Rotating conic-gradient "After-card" border
+
+In `projects/web/src/app/globals.css`, used by `IfStatementsToCheckPermission.tsx` on `/products/authzed-cloud`. Animates a conic gradient angle via the registered custom property:
+
+```css
+@property --az-after-angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+.az-after-rotating-border {
+  background: conic-gradient(from var(--az-after-angle),
+    #ffb370 0%, #f9808a 25%, #7a5ce6 50%, #a5318a 75%, #ffb370 100%);
+  animation: az-after-spin 10s linear infinite;
+}
+@keyframes az-after-spin { to { --az-after-angle: 360deg; } }
+```
+
+Special-purpose elevation chrome — signals "this is the answer." Use sparingly (one per page). Under reduced motion it falls back to a static `linear-gradient(90deg, #ffb370, #f9808a, #6242e0)` with `animation: none`.
+
+### Ambient float / parallax (storybook surfaces)
+
+The `resources/dibs-and-the-magic-library` story pages carry the bulk of looping ambient motion (`DibsHero.css`, `ParallaxStorySection.css`, `FlipbookReader.css`). Representative values, all infinite + `ease-in-out` unless noted:
+
+- `float` `4s`, `float-reverse` `5s`, `float-gentle` `6s` — gentle `translateY` + slight `rotate` drift on illustrations.
+- `illustration-float` `8s ease-in-out infinite` — `translateY(0→-8px→4px)` with sub-degree rotation.
+- `twinkle` `2s` / `twinkle-delayed` `3s` — sparkle opacity pulses.
+- `glow-pulse` `3s` — hero glow pulse (distinct from the design-system `glow`).
+- `shimmer` `4s linear infinite`, `book-reveal` `1s cubic-bezier(0.4, 0, 0.2, 1) forwards`, loading `spin`.
+- Card hover lift: `transform 0.4s` + `box-shadow 0.4s`, both `cubic-bezier(0.4, 0, 0.2, 1)`; depth via static `translateZ`/`scale` layers (no scroll-driven JS parallax in CSS — the layering is transform-based).
+
+### Marquee logo wall
+
+`CustomerLogoWall.css` defines `marquee-left` / `marquee-right` keyframes (`translateX(0 ↔ -33.333%)`) and applies `will-change: transform`. The animation duration/play state is driven from JS, not the CSS file. The `LogoCarousel.tsx` rotating-logo variant manages its slide states in JS (entrance → idle → slide-out/in) rather than a single CSS loop.
+
+### Not found in shipped code as of this writing
+
+- No spring/overshoot easing (`cubic-bezier(0.34, 1.56, …)` or similar) — does not exist anywhere.
+- No `prefers-reduced-motion` handling in the Sandworm **design-system** app (`projects/design/sandworm/`) — the reduced-motion implementations all live in `projects/web/`.
+- No global "scale all durations" reduced-motion sweep in `globals.css`; reduced motion is handled per-surface (see below). The hub's global-wildcard snippet is the recommended pattern, not a verbatim copy of what currently ships.
+
+## Reduced motion
+
+`@media (prefers-reduced-motion: reduce)` is **non-optional** for any animated surface. The marketing site implements it per-surface rather than via one global wildcard:
+
+- **`globals.css`** — the rotating After-card border drops to `animation: none` + a static linear-gradient fallback.
+- **`Hero.css`** — `.hero-node` transitions disabled.
+- **`CustomerLogoWall.css`** — marquee `animation: none !important`.
+- **`ParallaxStorySection.css` / `DibsHero.css` / `FlipbookReader.css`** — floating/twinkle/spinner loops set to `animation: none`.
+- **JS guards** — `HeroDiagram.tsx` and `LogoCarousel.tsx` read `window.matchMedia('(prefers-reduced-motion: reduce)')` and halt their `requestAnimationFrame`/rotation loops when it matches.
+
+When adding a new animation, ship its reduced-motion off-switch in the same change. If an animation can't degrade gracefully, gate it explicitly. The hub documents a global-wildcard snippet as the recommended baseline.
+
+## Do / Don't
+
+- **Do** run hover/focus feedback on `fast (200ms)`, feature lifts on `slow (500ms)`, and reach for `ease-in-out` by default; `ease-out` for entrances.
+- **Do** pair every animated surface with a `prefers-reduced-motion: reduce` rule in the same change.
+- **Don't** add spring or overshoot easing — none ships, and bounce breaks the restrained register. Sandworm motion glides; it never springs.
+- **Don't** use sub-`200ms` durations on hover states — they read as snap-not-glide. (`100ms` exists only on a couple of legacy prose-link transitions; don't extend the pattern.)

--- a/sandworm/design/components.md
+++ b/sandworm/design/components.md
@@ -1,0 +1,332 @@
+---
+name: Sandworm — Components
+description: Full component token specs + per-component detail for the Sandworm design system.
+part-of: Sandworm
+---
+
+> **Primitive tokens** (`{colors.*}`, `{typography.*}`, `{spacing.*}`, `{motion.*}`, `{rounded.*}`, `{elevation.*}`) are defined in the hub at [`../DESIGN.md`](../DESIGN.md). Load the hub alongside this spoke.
+
+← Back to [Sandworm DESIGN.md](../DESIGN.md)
+
+## Component tokens
+
+```yaml
+components:
+  # All button variants share these state tokens (focus + disabled) — declared once, referenced via state-* keys
+  button-states-shared:
+    focusVisible:
+      outline: none
+      ring:
+        color: "{colors.magenta.600}"
+        width: 2px
+        offsetWidth: 2px
+        offsetColor-dark: "{colors.stone.950}"
+        offsetColor-light: "{colors.stone.025}"
+    disabled:
+      pointerEvents: none
+      opacity: 0.5
+
+  # Primary brand button — pill, mono uppercase, gradient BORDER w/ dark fill (default)
+  # Source: projects/web/src/components/ui/GradientButton.tsx
+  button-primary:
+    shape: pill                              # rounded-full (9999px)
+    variant: outline                         # gradient border, stone-950 inner
+    background: linear-gradient(to right, "{colors.sand.300}", "{colors.red.400}", "{colors.violet.500}")
+    backgroundSize: "200% 200%"
+    backgroundPosition: left center
+    backgroundPosition-hover: right center
+    transform-hover: scale(1.02)
+    innerBackgroundColor: "{colors.stone.950}"
+    textColor: "{colors.stone.200}"
+    textColor-hover: "{colors.stone.025}"
+    padding: 10px 24px
+    borderWidth: 2px                         # outer wrapper p-[2px] creates the gradient border
+    typography:
+      fontFamily: "{typography.fontFamily.mono}"
+      fontSize: 0.75rem
+      fontWeight: 500
+      letterSpacing: 0.1em
+      textTransform: uppercase
+    states: "{components.button-states-shared}"   # all buttons share focus + disabled behavior
+    notes: "GradientButton outline variant. Gradient slides L→R on hover + 1.02 scale. Filled variant uses solid gradient fill w/ stone-950 text."
+
+  # Primary filled — solid gradient fill, dark text
+  button-primary-filled:
+    shape: pill
+    background: linear-gradient(to right, "{colors.sand.300}", "{colors.red.400}", "{colors.violet.500}")
+    backgroundSize: "200% 200%"
+    textColor: "{colors.stone.950}"          # dark text on warm gradient
+    padding: 10px 24px
+    typography: "{components.button-primary.typography}"
+
+  # Outline button — transparent w/ stone-100 border
+  button-outline:
+    shape: pill
+    backgroundColor: transparent
+    textColor: "{colors.stone.200}"
+    textColor-hover: "#ffffff"
+    backgroundColor-hover: rgba(255, 255, 255, 0.1)
+    borderColor: "{colors.stone.100}"
+    borderWidth: 1px
+    padding: 10px 24px
+    typography: "{components.button-primary.typography}"
+
+  # Subtle button — transparent w/ stone-600 border (quieter than outline)
+  button-subtle:
+    shape: pill
+    backgroundColor: transparent
+    textColor: "{colors.stone.300}"
+    textColor-hover: "#ffffff"
+    borderColor: "{colors.stone.600}"
+    borderColor-hover: "{colors.stone.500}"
+    borderWidth: 1px
+    padding: 10px 24px
+    typography: "{components.button-primary.typography}"
+
+  # NOTE: There is no canonical solid-magenta button in Sandworm.
+  # All primary CTAs go through `button-primary` (GradientButton). The solid-magenta-bg patterns
+  # visible on HubSpot form vendor buttons and the calendly inline CTA are vendor-form drift
+  # — they reflect "make the vendor button look vaguely AuthZed" patches, not canonical design.
+  # If a new surface needs a solid CTA, use `button-primary-filled` (warm gradient + dark text).
+  # The Button.tsx `variant="primary"` definition (magenta-600 + violet-500 border) is also
+  # deprecated by this spec — never used as-defined in production.
+
+  # Hero pattern — canonical AuthZed marketing surface opening
+  # Pattern: eyebrow → h1-with-emphasis-span → subtitle. Used at top of every product/use-case page.
+  # Example: 'Every authorization use case.' (font-light) + 'One system.' (font-semibold + magenta-600).
+  hero:
+    paddingTop: "{spacing.rhythm.hero-vertical}"
+    paddingBottom: "{spacing.rhythm.section-vertical-desktop}"
+    eyebrow:
+      typography: "{typography.label-caps}"
+      color: "{colors.stone.400}"
+      marginBottom: "{spacing.rhythm.eyebrow-to-title}"
+    title:
+      typography: "{typography.h1}"
+      marginBottom: "{spacing.6}"
+    titleEmphasis:                           # the "One system." span inside the h1
+      fontWeight: 600
+      color: "{colors.magenta.600}"
+    titleEmphasisAlt:                        # alternate brand-gradient emphasis (hero brand mark)
+      fontWeight: 600
+      background: linear-gradient(to right, "{colors.sand.300}", "{colors.red.400}", "{colors.violet.500}")
+      backgroundClip: text
+      textColor: transparent
+    subtitle:
+      typography: "{typography.body}"
+      color: "{colors.stone.300}"
+      maxWidth: 640px
+      fontSize: 1.125rem                     # subtitle is +1 step from body
+    notes: "Two emphasis modes: solid magenta-600 for in-prose emphasis, brand-gradient text-fill for hero brand marks. Use gradient sparingly — once per hero, never inside body paragraphs."
+
+  # Standard content card (dark backdrop with magenta hover)
+  card-dark:
+    backgroundColor: "{mode-dark.surfaceElevated}"   # references composed rgba — no separate opacity key
+    borderColor: "{colors.stone.700}"
+    borderColor-hover: "rgba(165, 49, 138, 0.6)"     # magenta-600 at 60% — composed
+    boxShadow-hover: "{elevation.card-glow-dark.boxShadow}"   # single source of truth — no duplication
+    rounded: "{rounded.xl}"
+    padding: "{spacing.rhythm.card-padding}"
+    backdropFilter: blur(4px)
+    transition:
+      duration: "{motion.duration.slow}"
+      easing: "{motion.easing.standard}"
+    # Sub-elements — typography roles inside the card body
+    eyebrow:
+      typography: "{typography.label-caps}"
+      color: "{colors.magenta.600}"          # magenta accent eyebrow (signature pattern)
+      marginBottom: "{spacing.rhythm.eyebrow-to-title}"
+    title:
+      typography: "{typography.h3}"
+      color: "{colors.stone.025}"
+      marginBottom: "{spacing.rhythm.title-to-body}"
+    body:
+      typography: "{typography.body}"
+      color: "{colors.stone.300}"
+    footer:                                  # optional bottom row (link, metadata)
+      typography: "{typography.caption}"
+      color: "{colors.stone.500}"
+      marginTop: "{spacing.4}"
+      borderTop: 1px solid "{colors.stone.800}"
+      paddingTop: "{spacing.3}"
+
+  # Light-mode card — sibling to card-dark, for light surfaces (docs, marketing-light, print fallback)
+  card-light:
+    backgroundColor: "{mode-light.surface}"          # stone-025
+    borderColor: "{mode-light.border}"               # stone-150
+    borderColor-hover: "rgba(165, 49, 138, 0.4)"     # magenta-600 at 40% — composed
+    boxShadow-hover: "{elevation.card-glow-light.boxShadow}"  # single source of truth
+    rounded: "{rounded.xl}"
+    padding: "{spacing.rhythm.card-padding}"
+    transition:
+      duration: "{motion.duration.slow}"
+      easing: "{motion.easing.standard}"
+    eyebrow:
+      typography: "{typography.label-caps}"
+      color: "{colors.magenta.600}"          # magenta still works on light
+      marginBottom: "{spacing.rhythm.eyebrow-to-title}"
+    title:
+      typography: "{typography.h3}"
+      color: "{colors.stone.900}"
+      marginBottom: "{spacing.rhythm.title-to-body}"
+    body:
+      typography: "{typography.body}"
+      color: "{colors.stone.700}"
+    footer:
+      typography: "{typography.caption}"
+      color: "{colors.stone.500}"
+      marginTop: "{spacing.4}"
+      borderTop: 1px solid "{colors.stone.150}"
+      paddingTop: "{spacing.3}"
+    notes: "Use on documentation surfaces, blog index, anywhere stone-025 is the page background. Light surfaces are the minority — most product/marketing pages run dark."
+
+  # Callout — subtle 5%/15% tints, dot+label TOP, body BELOW
+  # Source: projects/web/.worktrees/web-28-ai-resources/src/components/ai-authorization/Callout.tsx
+  callout-red:
+    backgroundColor: "{colors.red.500}"
+    backgroundOpacity: 0.05                  # /5 — VERY subtle
+    borderColor: "{colors.red.500}"
+    borderOpacity: 0.15                      # /15 — barely-there border
+    borderWidth: 1px
+    dotColor: "{colors.red.400}"             # dot uses -400, not -500
+    labelColor: "{colors.red.400}"
+    bodyTextColor: "{colors.stone.200}"
+    rounded: "{rounded.md}"
+    padding: 16px
+    layout: dot-label-on-top
+    labelTypography: "{typography.label-caps}"
+  callout-teal:
+    backgroundColor: "{colors.teal.500}"
+    backgroundOpacity: 0.05
+    borderColor: "{colors.teal.500}"
+    borderOpacity: 0.15
+    borderWidth: 1px
+    dotColor: "{colors.teal.400}"
+    labelColor: "{colors.teal.400}"
+    bodyTextColor: "{colors.stone.200}"
+    rounded: "{rounded.md}"
+    padding: 16px
+    layout: dot-label-on-top
+  callout-violet:
+    backgroundColor: "{colors.violet.500}"
+    backgroundOpacity: 0.05
+    borderColor: "{colors.violet.500}"
+    borderOpacity: 0.20                      # violet bumped to /20 per source
+    borderWidth: 1px
+    dotColor: "{colors.violet.400}"
+    labelColor: "{colors.violet.400}"
+    bodyTextColor: "{colors.stone.200}"
+    rounded: "{rounded.md}"
+    padding: 16px
+    layout: dot-label-on-top
+  callout-stone:
+    backgroundColor: "{colors.stone.900}"
+    backgroundOpacity: 0.40                  # stone variant is denser (status-neutral)
+    borderColor: "{colors.stone.600}"
+    borderOpacity: 0.30
+    borderWidth: 1px
+    dotColor: "{colors.stone.400}"
+    labelColor: "{colors.stone.400}"
+    bodyTextColor: "{colors.stone.200}"
+    rounded: "{rounded.md}"
+    padding: 16px
+    layout: dot-label-on-top
+    notes: "Neutral aside — info without status charge."
+
+  # Terminal window chrome (for code-as-evidence panels)
+  terminal-window:
+    backgroundColor: "#0F0E14"               # near-stone-975, slightly bluer for terminal feel
+    chromeColors: ["{colors.red.500}", "{colors.sand.300}", "{colors.teal.500}"]
+    rounded: "{rounded.lg}"
+
+  # Section labels (mono caps) — used as structural markers above headings
+  section-label:
+    typography: "{typography.label-caps}"
+    color: "{colors.stone.400}"               # default neutral; use magenta-600 for emphasis variant
+    color-emphasis: "{colors.magenta.600}"    # emphasized variant (signals "this section matters")
+    marginBottom: "{spacing.rhythm.eyebrow-to-title}"
+
+  # Section rule — horizontal rule paired with section labels in archive/list patterns
+  # Pattern: SECTION LABEL above + horizontal rule below (or sandwich w/ rules top + bottom)
+  section-rule:
+    color: "{colors.stone.800}"               # dark-mode rule color
+    color-light: "{colors.stone.150}"         # light-mode rule color
+    width: 1px
+    style: solid
+    # Layout variants:
+    # — bottom: rule beneath label (most common, opening pattern)
+    # — top: rule above label (rare; used as section closer)
+    # — sandwich: rules above AND below label (used for archive separators)
+    layout: bottom
+    # Mono-caps "Load more" pattern uses sandwich layout w/ stone-800 rules
+
+  # Code block (multi-line, fenced)
+  code-block:
+    typography: "{typography.code-block}"
+    backgroundColor: "{colors.stone.900}"
+    textColor: "{colors.stone.200}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.4} {spacing.6}"        # 16px vertical, 24px horizontal
+    syntaxColors:                             # highlight.js theme alignment
+      keyword: "{colors.violet.400}"
+      string: "{colors.sand.300}"
+      function: "{colors.teal.400}"
+      comment: "{colors.stone.500}"
+      number: "{colors.magenta.400}"
+      operator: "{colors.stone.300}"
+    notes: "Stone-900 surface (slightly lighter than card-dark to read as inset code). Inline code uses the lighter chrome on stone-900 padding."
+```
+
+## Component detail
+
+### Hero pattern
+Every product, use-case, industry, and marketing landing page opens with the same structure: mono-caps eyebrow → font-light h1 with magenta-600 (or brand-gradient) emphasis span → font-light body subtitle (max-width ~640px).
+
+The emphasis span is the working surface of the brand. Two modes:
+- **Solid magenta-600 semibold** (default) — for in-prose emphasis, headline punchlines, comparison contrasts
+- **Brand-gradient text-fill** (rare, hero-only) — used as the page's brand mark, never inside body paragraphs
+
+Example: "Every authorization use case." (font-light) + "One system." (font-semibold + magenta-600). The contrast of weights inside a single sentence is the AuthZed headline fingerprint.
+
+### Card sub-elements
+A card-dark or card-light has four optional roles:
+- **Eyebrow** — mono-caps in magenta-600 (signals "this card belongs to a category")
+- **Title** — h3-weight (font-normal at 1.5rem)
+- **Body** — font-light body prose, stone-300 on dark / stone-700 on light
+- **Footer** — caption-weight, separated by a stone-800 top border (or stone-150 on light)
+
+Skip eyebrow on standalone cards (e.g., testimonials, hero-adjacent CTAs). Always pair eyebrow with title — eyebrow without title reads as orphan label.
+
+### Section labels & rules
+Mono-caps section labels are structural markers — they say "you've entered a new region." Three layouts:
+- **bottom-rule** (default opening pattern) — `LABEL` on top, `border-b border-stone-800` below
+- **top-rule** (closer) — `border-t border-stone-800` above, `LABEL` below
+- **sandwich** (archive separator) — rules above AND below the label, used in blog/learn archive lists
+
+The mono-caps "Load more" affordance at the bottom of ArchiveList uses the sandwich layout with stone-800 rules. The horizontal rule is **always 1px stone-800 on dark** (or stone-150 on light) — heavier weights read as section dividers, which is a different vocabulary.
+
+### `GradientButton` — Brand-default primary CTA
+Sand→red→violet animated gradient. Used for the canonical "Sign up", "Get started" actions. Carries animated gradient shift on hover.
+
+### `Callout` (red / teal / violet / stone variants)
+Dot + label + body pattern. Lives at `projects/web/src/components/ai-authorization/Callout.tsx`. Used for in-section explainers; dim-inactive + ring-active pattern when stacked for comparison.
+
+### `TerminalWindow`
+Red / amber / teal traffic-light dots + `#0F0E14` chrome. Used for code-as-evidence panels (before/after comparisons, schema demos). Lives at `projects/web/src/components/ai-authorization/TerminalWindow.tsx`.
+
+### `RelationshipsTable`
+Auto-cycling row highlight + "Streaming" indicator. Honest visual motion — implies a graph being queried without implying a backend round-trip. Replaces the killed "LiveChecks" pattern (which falsely implied real-time API calls).
+
+### `ArchiveList`
+Shared blog-archive list component. Supports `isUndated` prop for non-blog usage (e.g., resources lists). Mono-caps "Load more" between horizontal rules.
+
+### `SectionLabel`
+Mono-caps section markers. Pairs with horizontal rules on archive/list surfaces.
+
+### `Card` (shadcn primitive)
+The **base** shadcn `Card` (`components/ui/card.tsx`) is plain: `rounded-lg` (8px), `border`, `shadow-sm`, **no hover lift** — verified 2026-06-03. The expressive **marketing `card-dark` composite** (a different pattern, not the base primitive) adds: `stone-950/90` bg, `stone-700` border, hover `magenta-600/60` border + magenta glow, `backdrop-blur-sm`, `rounded-xl`, `p-6`. Don't conflate the two — reach for the base Card for product/dense chrome, the composite for marketing surfaces.
+
+### `Alert` (shadcn primitive — voice/tone usage)
+Variants: `success` (teal), `warning` (sand), `error` (red), `destructive` (stone-inverted), `creative` (violet). Used in form validation and status messaging.
+
+> TODO[design-team]: Application-tier components in `projects/web/src/components/` are not yet promoted into Sandworm's `components/ui/`. Candidates for promotion: `Callout`, `TerminalWindow`, `RelationshipsTable`, `IfStatementsToCheckPermission`. Surface them in Sandworm so they're discoverable across products, not just authzed.com.

--- a/sandworm/design/dataviz.md
+++ b/sandworm/design/dataviz.md
@@ -1,0 +1,155 @@
+---
+name: Sandworm — Data Visualization
+description: The Chroma-Charts Rakis chart palette system for Sandworm.
+part-of: Sandworm
+---
+
+> **Primitive tokens** (`{colors.*}`, `{typography.*}`, `{spacing.*}`, `{motion.*}`, `{rounded.*}`, `{elevation.*}`) are defined in the hub at [`../DESIGN.md`](../DESIGN.md). Load the hub alongside this spoke.
+
+← Back to [Sandworm DESIGN.md](../DESIGN.md)
+
+## Data Visualization tokens
+
+```yaml
+# Data Visualization — the Chroma-Charts Rakis palette system
+# Reference implementations:
+#   - projects/web/src/components/cloud/CloudMetricsCarousel.tsx (5-value, dashboards)
+#   - projects/web/src/app/(main)/assessment/HexRadarChart.tsx (3-axis radar)
+#   - projects/web/src/components/mdx/custom/GoogleScaleChart.tsx (theme-aware)
+#   - projects/design/sandworm/components/ui/chart.tsx (shadcn ChartContainer wrapping recharts)
+#
+# Rakis is VALUE-COUNT-BASED. For a chart with N data series, use the N-value palette —
+# each palette adjusts ALL stops when value count changes. DO NOT take "5-value plus
+# one more color" — use the 6-value palette (its stops re-balance to support 6).
+dataviz:
+  system: "Rakis (Chroma-Charts)"
+  sourceFile: "BigBrain 11.02 / Rakis-chart-colors.css"
+  primitive: "components/ui/chart.tsx (shadcn ChartContainer + recharts)"
+
+  # The single most important Rakis rule. Counter-intuitive but correct.
+  surface-rule:
+    use-on-dark: "root-block-bright-variants"     # `:root` block — bright values that pop
+    use-on-light: "dark-block-muted-variants"     # `.dark` block — darker muted values
+    rationale: |
+      Counter-intuitive but correct: dark dashboards use the BRIGHT (`:root`) palette because
+      muted colors read muddy on dark backgrounds. Light surfaces use the muted (`.dark`)
+      palette because bright colors blow out on light. This inverts the naming intuition —
+      the `:root` block ships on DARK surfaces, the `.dark` block ships on LIGHT surfaces.
+    code-reference: "Rule documented inline at CloudMetricsCarousel.tsx:15-25"
+
+  # Default 5-value palette — most common, used in CloudMetricsCarousel dashboards
+  # Sandworm-native names (chroma-charts file has off-by-one labels with same hex —
+  # the file's `magenta-700` is the same hex as Sandworm's `magenta-600`, etc.
+  # CloudMetricsCarousel comment block explains the mapping)
+  default-5-value:
+    1: { token: "{colors.sand.300}", hex: "#ffb370" }
+    2: { token: "{colors.red.500}", hex: "#f0566d" }
+    3: { token: "{colors.magenta.600}", hex: "#a5318a" }
+    4: { token: "{colors.violet.300}", hex: "#ad96f3" }
+    5: { token: "{colors.teal.400}", hex: "#72b1ad" }
+    notes: "Used in CloudMetricsCarousel for production-realistic SpiceDB ops dashboards (CheckPermission volume, AtLeastAsFresh ratios, latency percentiles)."
+
+  # 3-axis radar pattern — assessment HexRadarChart
+  # These are the brand-gradient stops (sand → red → violet) used as axis colors.
+  # Different from the 5-value palette — radar uses brighter "-400" stops because
+  # the polygon fills are semi-transparent and need saturation to read.
+  axis-3-radar:
+    performance: { token: "{colors.sand.300}", hex: "#ffb370" }
+    risk: { token: "{colors.red.400}", hex: "#f9808a" }
+    agility: { token: "{colors.violet.400}", hex: "#9278ed" }
+    source: "projects/web/src/app/(main)/assessment/HexRadarChart.tsx:37-41"
+    notes: "Sand-300 / red-400 / violet-400 — distinct from the 5-value palette's red-500/violet-300. Radar canon, not dashboard canon."
+
+  # Per-value palette scale — full table in Rakis-chart-colors.css (palettes for 2-20 values)
+  # The most common counts:
+  per-value-palettes:
+    "2": ["{colors.sand.300}", "{colors.red.500}"]
+    "3": ["{colors.sand.300}", "{colors.red.500}", "{colors.magenta.600}"]
+    "4": ["{colors.sand.300}", "{colors.red.500}", "{colors.magenta.600}", "{colors.violet.300}"]
+    "5": ["{colors.sand.300}", "{colors.red.500}", "{colors.magenta.600}", "{colors.violet.300}", "{colors.teal.400}"]
+    "6": ["{colors.sand.300}", "{colors.red.400}", "{colors.red.500}", "{colors.magenta.600}", "{colors.violet.300}", "{colors.teal.400}"]
+    "7": ["{colors.sand.300}", "{colors.red.400}", "{colors.red.500}", "{colors.magenta.500}", "{colors.magenta.600}", "{colors.violet.300}", "{colors.teal.400}"]
+    # 8 through 20 — see source file. Each adds stops by expanding the palette, not appending.
+    notes: "When data-series count changes, swap palettes — DON'T extend by appending. Each palette is a re-balanced set."
+
+  # Chart chrome — supporting structural colors
+  chrome:
+    gridlineColor-dark: "{colors.stone.800}"
+    gridlineColor-light: "{colors.stone.150}"
+    axisLabelColor-dark: "{colors.stone.400}"
+    axisLabelColor-light: "{colors.stone.500}"
+    axisLineColor-dark: "{colors.stone.700}"
+    axisLineColor-light: "{colors.stone.200}"
+    tooltipBackground-dark: "{colors.stone.950}"
+    tooltipBackground-light: "#ffffff"
+    tooltipBorder-dark: "{colors.stone.700}"
+    tooltipBorder-light: "{colors.stone.150}"
+    legendLabelTypography: "{typography.label-caps}"
+
+  # Defaults applied to all charts in the system
+  defaults:
+    fontFamily: "{typography.fontFamily.sans}"
+    fontSize: "0.875rem"
+    labelFontSize: "0.75rem"
+    barRadius: "{rounded.sm}"               # 4px — bar corners
+    lineWidth: 2
+    pointRadius: 4
+    pointHoverRadius: 6
+    animationDuration: "{motion.duration.base}"   # 300ms — chart-render animation
+
+  notes: |
+    DO NOT invent categorical / sequential / diverging palettes alongside Rakis — Rakis IS
+    the system. (Earlier drafts of this spec had an invented 7-color sequence starting with
+    magenta-600 + a status palette + intensity ramps — all wrong. Sandworm canon starts with
+    sand-300, uses value-count-indexed palettes, and follows the surface-rule.) Read
+    Rakis-chart-colors.css for the full per-value table.
+```
+
+## Data Visualization
+
+Sandworm's chart system is **Chroma-Charts Rakis** — a value-count-based palette family. Reference implementations ship in `projects/web/src/components/cloud/CloudMetricsCarousel.tsx` (5-value dashboards), `projects/web/src/app/(main)/assessment/HexRadarChart.tsx` (3-axis radar), and `projects/design/sandworm/components/ui/chart.tsx` (the shadcn ChartContainer wrapping recharts).
+
+> **Earlier drafts of this spec invented a 7-color categorical sequence + status palette + intensity ramps.** That was wrong — Sandworm has Rakis, and Rakis IS the dataviz canon. The corrected description follows.
+
+### How Rakis works
+
+Rakis is **value-count-indexed**. For a chart with N data series, use the N-value palette. The palette re-balances when N changes — you do NOT take "5-value plus one more color" — you swap to the 6-value palette, which redistributes ALL stops to support 6 series.
+
+The default and most common palette is **5-value**:
+
+1. **Sand 300** — `#ffb370`
+2. **Red 500** — `#f0566d`
+3. **Magenta 600** — `#a5318a`
+4. **Violet 300** — `#ad96f3`
+5. **Teal 400** — `#72b1ad`
+
+For other counts, see the per-value-palettes YAML table or the source CSS file (which carries the full 2-through-20 value range).
+
+### The Rakis surface rule (load-bearing, counter-intuitive)
+
+**On DARK surfaces, use the BRIGHT (`:root`) variants. On LIGHT surfaces, use the MUTED (`.dark`) variants.**
+
+This inverts naming intuition. The reason: muted colors read muddy on dark backgrounds, and bright colors blow out on light. The `:root` block in `Rakis-chart-colors.css` has the bright pop colors that work on dark dashboards; the `.dark` block has the deeper muted variants that hold up against light pages.
+
+This rule is documented inline at `CloudMetricsCarousel.tsx:15-25` — when in doubt, read that comment block.
+
+### Radar charts use a different palette
+
+The assessment `HexRadarChart` uses the **3-axis radar palette** — distinct from the 5-value default:
+
+- **Performance** — sand-300 (`#ffb370`)
+- **Risk** — red-400 (`#f9808a`) ← red-400, NOT red-500
+- **Agility** — violet-400 (`#9278ed`) ← violet-400, NOT violet-300
+
+These are the brand-gradient stops applied as axis colors. Brighter "-400" stops because the polygon fills are semi-transparent and need saturation to register through the overlay. Source: `HexRadarChart.tsx:37-41`.
+
+### Chart chrome
+
+Gridlines, axes, labels, and tooltips use the stone scale. Two rules:
+
+- **Gridlines must whisper, not shout** — stone-800 on dark, stone-150 on light. If gridlines compete with the data series, lighten them further.
+- **Legends use the mono-caps label style** (same as section labels) — signals "this is structural metadata, not content."
+
+### Don't invent
+
+The strongest dataviz guidance in this spec: **do not invent new palettes alongside Rakis**. No "categorical sequence starting with magenta-600." No "alert series at position 6." No diverging cool-warm palette. If a chart needs a treatment Rakis doesn't cover, surface it as a gap to fix in the canonical CSS, not as a parallel system in the consuming component.

--- a/sandworm/design/logo-brand.md
+++ b/sandworm/design/logo-brand.md
@@ -1,0 +1,106 @@
+---
+name: Sandworm — Logo & Brand Marks
+description: Logo/wordmark usage, fixed mark colors, clear space, and minimum sizes for AuthZed brand marks.
+part-of: Sandworm
+---
+
+> **Primitive tokens** (`{colors.*}`, `{typography.*}`, `{spacing.*}`, `{motion.*}`, `{rounded.*}`, `{elevation.*}`) are defined in the hub at [`../DESIGN.md`](../DESIGN.md). Load the hub alongside this spoke.
+
+← Back to [Sandworm DESIGN.md](../DESIGN.md)
+
+## Logo & Brand Mark tokens
+
+```yaml
+# Logo & brand marks — fixed assets, fixed colors, strict usage
+# The mark is the load-bearing brand artifact — drift here is the most expensive kind.
+logo:
+  assets:
+    wordmark-color: "public/assets/brand/AuthZed-Wordmark-Color.svg"
+    wordmark-slate: "public/assets/brand/AuthZed-Wordmark-Slate.svg"
+    logomark-circle-color: "public/assets/brand/logomark/authzed-logomark-circle-color.svg"
+    logomark-circle-slate: "public/assets/brand/logomark/authzed-logomark-circle-slate.svg"
+    stacked-color: "public/assets/brand/AuthZed-Stacked-Color.svg"
+    # SpiceDB sibling
+    spicedb-wordmark-color: "public/assets/brand/SpiceDB-Wordmark-Color.svg"
+    spicedb-wordmark-dark: "public/assets/brand/SpiceDB-Wordmark-Dark.svg"
+
+  # Logomark gradient — uses the canonical Sandworm palette tokens.
+  # The shipped SVGs currently carry legacy near-match hexes that predate the palette
+  # (#A43189 / #F0546C / #FFB371); these are un-reconciled drift, NOT an intentional
+  # separate brand palette, and should be re-derived to the tokens below.
+  logomark-colors:
+    magenta: "{colors.magenta.600}"   # #a5318a  (legacy SVG: #A43189 — reconcile)
+    coral: "{colors.red.500}"         # #f0566d  (legacy SVG: #F0546C — reconcile)
+    sand: "{colors.sand.300}"         # #ffb370  (legacy SVG: #FFB371 — effectively identical)
+
+  clearSpace:
+    rule: "Minimum padding around the wordmark = height of the wordmark's 'A' letterform"
+    rationale: "Ensures the mark never collides with adjacent elements; reads as deliberately placed, not crammed in."
+
+  minimumSize:
+    screen-wordmark: 80px      # below this, switch to logomark
+    screen-logomark: 24px
+    print-wordmark: 0.75in
+    print-logomark: 0.25in
+    favicon: 16px              # logomark-circle-color, minimum browser favicon
+
+  usage:
+    color-wordmark: "stone-025 OR stone-950 surfaces only"
+    slate-wordmark: "busy / photographic backgrounds (single-color reads cleaner against texture)"
+    color-logomark: "default standalone mark — favicons, avatars, condensed contexts"
+    stacked: "square layouts (social profile images, ads requiring squared composition)"
+
+  donts:
+    - "Recolor the logomark to non-brand colors — its gradient follows the Sandworm magenta-600 / red-500 / sand-300 tokens"
+    - "Apply drop shadows, glows, outlines, or any effect to the logo"
+    - "Stretch, skew, rotate, or distort the wordmark"
+    - "Place color wordmark on a colored background — it fights brand colors. Use slate variant on color."
+    - "Recreate the logo by typing 'AuthZed' in any font — always use the SVG/PNG asset"
+    - "Use the color wordmark smaller than 80px wide — switch to the logomark"
+    - "Combine wordmark + logomark in close proximity (use the stacked asset instead)"
+```
+
+## Logo & Brand Marks
+
+The logo is the most load-bearing single artifact in the brand. Drift here costs more than drift anywhere else — recoloring a button gradient is recoverable; recoloring a logomark in customer-facing material is not.
+
+**Canonical assets** live at `projects/web/public/assets/brand/` and `projects/design/sandworm/public/` (synchronized). Five variants matter:
+
+1. **Wordmark — Color** — default for color-permitting surfaces (white or dark backgrounds)
+2. **Wordmark — Slate** — single-color version for busy / photographic / colored backgrounds
+3. **Logomark (circle) — Color** — standalone mark; default favicon, avatar, condensed contexts
+4. **Logomark (circle) — Slate** — single-color logomark for the same constraints as slate wordmark
+5. **Stacked** — wordmark above logomark for squared social profile / ad layouts
+
+The SpiceDB sibling has its own Color and Dark wordmark variants under the same path.
+
+### Logomark colors = canonical Sandworm palette
+
+The logomark gradient uses the **canonical Sandworm palette tokens** — magenta-600, red-500, sand-300:
+
+- Magenta: `magenta-600` (`#a5318a`)
+- Coral: `red-500` (`#f0566d`)
+- Sand: `sand-300` (`#ffb370`)
+
+The shipped SVG assets still carry legacy near-match hexes (`#A43189` / `#F0546C` / `#FFB371`) that predate the current palette. These are **not** an intentional separate brand palette — they're un-reconciled drift and should be re-derived to the tokens above. **Use the Sandworm tokens.**
+
+> TODO[brand]: reconcile the logomark SVG gradient stops to `magenta-600` / `red-500` / `sand-300` (currently `#A43189` / `#F0546C` / `#FFB371`).
+
+### Clear space and minimum sizes
+
+- **Clear space** = the height of the wordmark's "A" letterform on all sides of the wordmark. Same rule for the logomark, using its own height as the reference.
+- **Wordmark minimum**: 80px on screen, 0.75 inch in print. Smaller than that, switch to the logomark.
+- **Logomark minimum**: 24px on screen, 0.25 inch in print. Below 24px, use the simplified favicon variant.
+
+### Do's and don'ts
+
+- ✅ Color wordmark on stone-025 OR stone-950 (the two canonical surfaces)
+- ✅ Slate wordmark on busy / photographic / colored backgrounds where color would compete
+- ✅ Stacked wordmark for squared compositions (social profiles, ads)
+- ❌ Never recolor the logomark off-brand — it uses the Sandworm magenta-600 / red-500 / sand-300 gradient
+- ❌ Never apply effects (shadow, glow, outline) — the mark stands on its own
+- ❌ Never stretch, skew, rotate, or distort the wordmark
+- ❌ Never place the color wordmark on a colored background — use slate instead
+- ❌ Never recreate the logo by typing "AuthZed" in any font — always use the SVG asset
+- ❌ Never use color wordmark below 80px — switch to logomark
+- ❌ Don't combine wordmark + logomark in close proximity — use the stacked asset instead


### PR DESCRIPTION
## Sandworm DESIGN.md — agent-facing design spec

Adds a machine-readable Sandworm design spec (google-labs-code `DESIGN.md` format) so teammates can hand AuthZed's visual identity to AI design tools from **one canonical source** in the repo, rather than re-deriving it per project.

### What's here
- **`sandworm/DESIGN.md`** (hub) — primitive tokens (colors, typography, spacing, motion, elevation, layout), foundational prose, and a manifest pointing to the spokes. This is what an agent loads.
- **`sandworm/design/`** (spokes, load per surface):
  - `components.md` — full component token specs + per-component detail
  - `dataviz.md` — Rakis chart palette system
  - `logo-brand.md` — logo/wordmark usage, mark colors, clear space
  - `accessibility.md` — contrast ratios, focus/states, vendor-prefix gotchas
  - `animation.md` — motion patterns, keyframes, reduced-motion

### Grounded in shipped code
Every contested value was ground-truthed against the actual codebase (`projects/web` + `sandworm`), which corrected several plausible-but-wrong assumptions:
- **Motion** — no spring/overshoot easing ships; Sandworm does not bounce (ease-out/in/in-out + Material bezier only)
- **Icons** — Lucide **2px** default (no override ships), not 1.5
- **Elevation** — multiple shipped forms by surface (magenta glow / neutral shadow / violet glow / base Card no-lift), not "glow only"
- **Radius** — system default `--radius` = 8px; 16px is marketing-only
- **Logomark** — documented on canonical palette tokens (magenta-600 / red-500 / sand-300)

### Open / follow-ups (flagged in-spec)
- Brand-gradient violet end-stop `-500` vs `-600` (`#6242e0`) unresolved — needs a full grep before canonizing
- `TODO[brand]`: reconcile logomark SVG gradient stops (`#A43189`/`#F0546C`/`#FFB371`) to the palette tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)